### PR TITLE
Address the case where filename normalization results in an empty string

### DIFF
--- a/atreal/massloader/adapter.py
+++ b/atreal/massloader/adapter.py
@@ -160,9 +160,11 @@ class MassLoader(object):
         # Therefore we use the FileNameNormalizer utiltiy.
         util = queryUtility(IFileNameNormalizer)
         try:
-            return util.normalize(txt)
+            normalized = util.normalize(txt)
         except UnicodeError:
-            return util.normalize(unicode(txt, self.encoding))
+            normalized = util.normalize(unicode(txt, self.encoding))
+
+        return normalized or u'empty_name'
 
     def _log(self, filename, title=(u"N/A"), size='0', url='',
              status=_(u"Failed"), info=None):

--- a/atreal/massloader/adapter.py
+++ b/atreal/massloader/adapter.py
@@ -19,6 +19,8 @@ from atreal.massloader import MassLoaderMessageFactory as _
 from atreal.massloader.interfaces import IMassLoader, IArchiveUtility
 from atreal.massloader.browser.controlpanel import IMassLoaderSchema
 
+from ZODB.POSException import ConflictError
+
 
 try:
     pkg_resources.get_distribution('plone.namedfile')
@@ -302,6 +304,9 @@ class MassLoader(object):
         )
         try:
             setField(obj=obj, data=data, filename=filename)
+        except ConflictError:
+            # Do not swallow conflict errors.
+            raise
         except Exception as e:
             self._logger.warning(
                 '_setData: Error setting field. '
@@ -405,6 +410,9 @@ class MassLoader(object):
                     obj.reindexObject()
                     #
                     code = FOLDERCREATEOK
+                except ConflictError:
+                    # Do not swallow conflict errors.
+                    raise
                 except Exception as e:
                     self._logger.warning(
                         '_createObject: Error creating folder. '
@@ -432,6 +440,9 @@ class MassLoader(object):
                     notify(ObjectModifiedEvent(obj))
                     #
                     code = UPDATEOK
+                except ConflictError:
+                    # Do not swallow conflict errors.
+                    raise
                 except Exception as e:
                     self._logger.warning(
                         '_createObject: Error replacing existing item data. '
@@ -466,6 +477,9 @@ class MassLoader(object):
                     notify(ObjectCreatedEvent(obj))
                     #
                     code = CREATEOK
+                except ConflictError:
+                    # Do not swallow conflict errors.
+                    raise
                 except Exception as e:
                     self._logger.warning(
                         '_createObject: Error creating new item. '

--- a/atreal/massloader/adapter.py
+++ b/atreal/massloader/adapter.py
@@ -1,6 +1,8 @@
 import transaction
 import pkg_resources
 
+from logging import getLogger
+
 from zope.i18n import translate
 from zope.interface import implements
 from zope.component import queryUtility
@@ -86,6 +88,11 @@ class MassLoader(object):
         props = getToolByName(self.context, 'portal_properties')
         stp = props.site_properties
         self.view_types = stp.getProperty('typesUseViewActionInListings', ())
+
+        # Logger for debugging only.
+        t = type(self)
+        self._logger = getLogger(t.__module__ + '.' + t.__name__)
+
 
     @property
     def _options(self):
@@ -295,7 +302,11 @@ class MassLoader(object):
         )
         try:
             setField(obj=obj, data=data, filename=filename)
-        except:
+        except Exception as e:
+            self._logger.warning(
+                '_setData: Error setting field. '
+                'obj={}, filename={}, str(e)={}, repr(e)={}'.format(obj, filename, str(e), repr(e))
+            )
             return False
 
     def _setField(self, obj, data, filename, fieldName, namedFileClass):
@@ -394,7 +405,13 @@ class MassLoader(object):
                     obj.reindexObject()
                     #
                     code = FOLDERCREATEOK
-                except:
+                except Exception as e:
+                    self._logger.warning(
+                        '_createObject: Error creating folder. '
+                        'id={}, title={}, container={}, filename={}, str(e)={}, repr(e)={}'.format(
+                            id, title, container, filename, str(e), repr(e)
+                        )
+                    )
                     #
                     return False, FOLDERCREATEERROR, None, ""
         else:
@@ -415,7 +432,13 @@ class MassLoader(object):
                     notify(ObjectModifiedEvent(obj))
                     #
                     code = UPDATEOK
-                except:
+                except Exception as e:
+                    self._logger.warning(
+                        '_createObject: Error replacing existing item data. '
+                        'id={}, title={}, container={}, filename={}, str(e)={}, repr(e)={}'.format(
+                            id, title, container, filename, str(e), repr(e)
+                        )
+                    )
                     #
                     return False, UPDATEERROR, None, ""
             else:
@@ -443,7 +466,13 @@ class MassLoader(object):
                     notify(ObjectCreatedEvent(obj))
                     #
                     code = CREATEOK
-                except:
+                except Exception as e:
+                    self._logger.warning(
+                        '_createObject: Error creating new item. '
+                        'id={}, title={}, container={}, filename={}, str(e)={}, repr(e)={}'.format(
+                            id, title, container, filename, str(e), repr(e)
+                        )
+                    )
                     #
                     return False, CREATEERROR, None, ""
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 3.2.0 (unreleased)
 ------------------
 
+- Do not swallow ConflictError. [rafaelbco]
 - Address the case where filename normalization results in an empty string [rafaelbco]
 - Use IFileNameNormalizer instead of CMFPlone.utils.normalizeString [foreverchild]
 - Dexterity compatibility. Tested with types from plone.app.contenttypes [rafaelbco]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 3.2.0 (unreleased)
 ------------------
 
+- Address the case where filename normalization results in an empty string [rafaelbco]
 - Use IFileNameNormalizer instead of CMFPlone.utils.normalizeString [foreverchild]
 - Dexterity compatibility. Tested with types from plone.app.contenttypes [rafaelbco]
 
@@ -13,7 +14,6 @@ Changelog
 ------------------
 
 - Package fix
-
 
 3.1.1 (2012-08-14)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.2.0.dev1'
+version = '3.2.0.dev2'
 
 long_description = (
     read('README.rst')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.2.0.dev2'
+version = '3.2.0.dev3'
 
 long_description = (
     read('README.rst')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.2.0.dev0'
+version = '3.2.0.dev1'
 
 long_description = (
     read('README.rst')


### PR DESCRIPTION
Example: a filename comprised of underscore characters only is normalized to an empty string. This causes an error.